### PR TITLE
Add responsive container layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -523,6 +523,18 @@ button {
     }
 }
 
+@media (max-width: 768px) {
+    .container {
+        flex-direction: column;
+    }
+
+    .form-container,
+    #dispatch-history-container,
+    form,
+    #dispatch-history-table {
+        width: 100%;
+    }
+}
 
 /* Responsive table design */
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add responsive layout rules to stack container vertically at 768px
- ensure table and form take full width on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf2931188832d82cfdae1195549aa