### PR TITLE
Improve payload and history scrolling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -242,6 +242,8 @@ button {
 /* Dynamic payload container */
 #payload-container {
     flex-direction: column;
+    max-height: 300px;
+    overflow-y: auto;
 }
 
 #add-payload-field {
@@ -579,6 +581,8 @@ button {
     #payload-container {
         gap: 10px; /* Add spacing between payload fields */
         flex-wrap: wrap; /* Wrap payload fields */
+        max-height: 300px;
+        overflow-y: auto;
     }
 
     .payload-field {
@@ -685,15 +689,18 @@ button:disabled {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    max-height: 300px;
+}
+
+#dispatch-history-table-wrapper {
+    max-height: 400px;
     overflow-y: auto;
 }
 
-#dispatch-history-container::-webkit-scrollbar {
+#dispatch-history-table-wrapper::-webkit-scrollbar {
     width: 6px;
 }
 
-#dispatch-history-container::-webkit-scrollbar-thumb {
+#dispatch-history-table-wrapper::-webkit-scrollbar-thumb {
     background-color: #9494D1;
     border-radius: 10px;
 }

--- a/index.html
+++ b/index.html
@@ -88,7 +88,8 @@
     </div>
     <div id="dispatch-history-container">
         <h2>History</h2>
-        <table id="dispatch-history-table">
+        <div id="dispatch-history-table-wrapper">
+            <table id="dispatch-history-table">
             <thead>
             <tr>
                 <th>Owner</th>
@@ -102,7 +103,8 @@
             <tbody>
             <!-- Rows will be dynamically added here -->
             </tbody>
-        </table>
+            </table>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- allow scrolling inside payload area
- create wrapper for history table so title stays fixed
- raise history table height limit

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_685d1de1e66c832d868f892522632e76