### PR TITLE
Add clear history button, improve scrolls

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -244,6 +244,7 @@ button {
     flex-direction: column;
     max-height: 300px;
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 #add-payload-field {
@@ -699,7 +700,7 @@ button:disabled {
 }
 
 #dispatch-history-table-wrapper {
-    max-height: 400px;
+    max-height: 540px;
     overflow-y: auto;
 }
 

--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
     </div>
     <div id="dispatch-history-container">
         <h2>History</h2>
+        <button id="clear-history" class="btn-action" type="button">Clear History</button>
         <div id="dispatch-history-table-wrapper">
             <table id="dispatch-history-table">
             <thead>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import {DispatchHistoryEntry, Status, WorkflowPayload} from "./types.js";
 import {loadFromLocalStorage, saveToLocalStorage, toggleLoader} from "./utils.js";
-import {dispatchWorkflow, saveDispatchHistory} from "./workflow.js";
+import {dispatchWorkflow, saveDispatchHistory, clearDispatchHistory} from "./workflow.js";
 import {displayDispatchHistory} from "./dom.js";
 
 declare const MicroModal: any;
@@ -12,6 +12,7 @@ const savePatCheckbox = document.getElementById("save-pat") as HTMLInputElement;
 const logHistoryCheckbox = document.getElementById("log-history") as HTMLInputElement;
 const loader = document.querySelector(".loading-container") as HTMLDivElement;
 const themeSwitch = document.getElementById("theme-switch") as HTMLInputElement;
+const clearHistoryButton = document.getElementById("clear-history") as HTMLButtonElement;
 
 const savedTheme = loadFromLocalStorage<string>("theme");
 if (savedTheme === "dark") {
@@ -129,3 +130,10 @@ window.addEventListener("DOMContentLoaded", () => {
         MicroModal.init();
     }
 });
+
+if (clearHistoryButton) {
+    clearHistoryButton.addEventListener("click", () => {
+        clearDispatchHistory();
+        displayDispatchHistory([]);
+    });
+}

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -34,3 +34,7 @@ export function saveDispatchHistory(dispatch: DispatchHistoryEntry): void {
     history.push(dispatch);
     localStorage.setItem("dispatch_history", JSON.stringify(history));
 }
+
+export function clearDispatchHistory(): void {
+    localStorage.removeItem("dispatch_history");
+}


### PR DESCRIPTION
## Summary
- make payload container scroll vertically only
- extend dispatch history height to 540px
- add 'Clear History' button and logic to wipe saved dispatches

## Testing
- `tsc`

------
https://chatgpt.com/codex/tasks/task_e_685d2506e51c832da13d424c37c4e4a8