### PR TITLE
Add confirmation modal and detail styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -699,6 +699,17 @@ button:disabled {
     gap: 20px;
 }
 
+.history-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#clear-history.small {
+    padding: 4px 8px;
+    font-size: 12px;
+}
+
 #dispatch-history-table-wrapper {
     max-height: 540px;
     overflow-y: auto;
@@ -907,5 +918,27 @@ button:disabled {
     padding: 8px;
     text-align: left;
     word-break: break-word;
+}
+
+.details-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.details-list li {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--input-border);
+}
+
+.details-list li:last-child {
+    border-bottom: none;
+}
+
+.details-label {
+    font-weight: 500;
+    color: #666;
 }
 

--- a/index.html
+++ b/index.html
@@ -88,8 +88,10 @@
         </form>
     </div>
     <div id="dispatch-history-container">
-        <h2>History</h2>
-        <button id="clear-history" class="btn-action" type="button">Clear History</button>
+        <div class="history-header">
+            <h2>History</h2>
+            <button id="clear-history" class="btn-action small" type="button">Clear</button>
+        </div>
         <div id="dispatch-history-table-wrapper">
             <table id="dispatch-history-table">
             <thead>
@@ -120,6 +122,24 @@
             <main class="modal__content" id="dispatch-details-content"></main>
             <footer class="modal__footer">
                 <button class="button" data-micromodal-close aria-label="Close this dialog window">Close</button>
+            </footer>
+        </div>
+    </div>
+</div>
+
+<div class="modal micromodal-slide" id="confirm-clear-history" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="confirm-clear-history-title">
+            <header class="modal__header">
+                <h2 class="modal__title" id="confirm-clear-history-title">Clear History</h2>
+                <button class="modal__close" aria-label="Close modal" data-micromodal-close>&times;</button>
+            </header>
+            <main class="modal__content">
+                <p>Are you sure you want to clear the dispatch history?</p>
+            </main>
+            <footer class="modal__footer">
+                <button id="confirm-clear-history-btn" class="button">Yes, Clear</button>
+                <button class="button" data-micromodal-close>No</button>
             </footer>
         </div>
     </div>

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -37,12 +37,14 @@ export function showDispatchDetails(entry: DispatchHistoryEntry): void {
     const container = document.getElementById("dispatch-details-content") as HTMLElement;
     if (!container) return;
     container.innerHTML = `
-        <p><strong>Repository:</strong> ${entry.owner}/${entry.repo}</p>
-        <p><strong>Workflow:</strong> ${entry.workflow}</p>
-        <p><strong>Branch:</strong> ${entry.ref}</p>
-        <p><strong>Status:</strong> ${entry.status}</p>
-        <p><strong>Timestamp:</strong> ${formatTimestamp(entry.timestamp)}</p>
-        ${entry.errorMessage ? `<p><strong>Error:</strong> ${entry.errorMessage}</p>` : ""}
+        <ul class="details-list">
+            <li><span class="details-label">Repository</span><span>${entry.owner}/${entry.repo}</span></li>
+            <li><span class="details-label">Workflow</span><span>${entry.workflow}</span></li>
+            <li><span class="details-label">Branch</span><span>${entry.ref}</span></li>
+            <li><span class="details-label">Status</span><span class="${entry.status}">${entry.status}</span></li>
+            <li><span class="details-label">Timestamp</span><span>${formatTimestamp(entry.timestamp)}</span></li>
+            ${entry.errorMessage ? `<li><span class="details-label">Error</span><span>${entry.errorMessage}</span></li>` : ""}
+        </ul>
     `;
 
     if (entry.payload && Object.keys(entry.payload).length > 0) {
@@ -107,7 +109,7 @@ export function displayDispatchHistory(history: DispatchHistory): void {
         // Status cell
         const statusCell = document.createElement("td");
         statusCell.textContent = entry.status;
-        statusCell.style.color = entry.status === "success" ? "green" : "red";
+        statusCell.className = entry.status === "success" ? "success" : "failure";
 
         // Timestamp cell
         const timestampCell = document.createElement("td");

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ const logHistoryCheckbox = document.getElementById("log-history") as HTMLInputEl
 const loader = document.querySelector(".loading-container") as HTMLDivElement;
 const themeSwitch = document.getElementById("theme-switch") as HTMLInputElement;
 const clearHistoryButton = document.getElementById("clear-history") as HTMLButtonElement;
+const confirmClearHistoryBtn = document.getElementById("confirm-clear-history-btn") as HTMLButtonElement;
 
 const savedTheme = loadFromLocalStorage<string>("theme");
 if (savedTheme === "dark") {
@@ -133,7 +134,18 @@ window.addEventListener("DOMContentLoaded", () => {
 
 if (clearHistoryButton) {
     clearHistoryButton.addEventListener("click", () => {
+        if (typeof MicroModal !== "undefined") {
+            MicroModal.show("confirm-clear-history");
+        }
+    });
+}
+
+if (confirmClearHistoryBtn) {
+    confirmClearHistoryBtn.addEventListener("click", () => {
         clearDispatchHistory();
         displayDispatchHistory([]);
+        if (typeof MicroModal !== "undefined") {
+            MicroModal.close("confirm-clear-history");
+        }
     });
 }


### PR DESCRIPTION
## Summary
- add smaller clear history button positioned to the right
- add confirmation modal to clear history
- style history modal content using Material-like list
- update TypeScript to handle modal logic

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_685d27495e88832db4b7eaf3073aa44e