### PR TITLE
Add GitHub star badge

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -834,6 +834,13 @@ button:disabled {
   top: 10px;
   right: 10px;
   z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.github-star-badge img {
+  height: 28px;
 }
 
 /* Modal Styling */

--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
 </head>
 <body>
 <div class="theme-toggle-wrapper">
+    <a class="github-star-badge" href="https://github.com/saedyousef/workflow-dispatcher" target="_blank" aria-label="Star saedyousef/workflow-dispatcher on GitHub">
+        <img src="https://img.shields.io/github/stars/saedyousef/workflow-dispatcher?style=social" alt="GitHub stars">
+    </a>
     <label class="ui-switch">
         <input type="checkbox" id="theme-switch">
         <div class="slider">


### PR DESCRIPTION
## Summary
- add GitHub stars badge for the repo next to the theme toggle switch
- style the badge so it aligns with the toggle

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_685d79663214832d863797be01892d8d