### PR TITLE
Fix toggle and payload layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -239,12 +239,24 @@ button {
     gap: 10px;
 }
 
+/* Ensure toggle rows remain horizontal on small screens */
+.form-row.theme-toggle,
+.form-row .theme-toggle {
+    flex-direction: row;
+    align-items: center;
+}
+
 /* Dynamic payload container */
 #payload-container {
+    display: flex;
     flex-direction: column;
+    flex-wrap: nowrap;
+    max-width: 100%;
+    width: 100%;
     max-height: 300px;
     overflow-y: auto;
     overflow-x: hidden;
+    margin-bottom: 15px;
 }
 
 #add-payload-field {
@@ -588,9 +600,16 @@ button {
 
     #payload-container {
         gap: 10px; /* Add spacing between payload fields */
-        flex-wrap: wrap; /* Wrap payload fields */
+        flex-direction: column;
+        flex-wrap: nowrap;
         max-height: 300px;
         overflow-y: auto;
+    }
+
+    .form-row.theme-toggle,
+    .form-row .theme-toggle {
+        flex-direction: row;
+        align-items: center;
     }
 
     .payload-field {

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
             <div class="form-row action-buttons">
                 <button class="btn-action" id="add-payload-field" type="button">Add Payload</button>
             </div>
-            <div id="payload-container" class="form-row">
+            <div id="payload-container">
 
             </div>
 


### PR DESCRIPTION
## Summary
- keep the Save PAT and Log History switches horizontal on mobile
- ensure the payload container scrolls vertically by default

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_685db5fca6c0832d92ab73cb06dafe22