### PR TITLE
Enhance layout and logging

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -188,8 +188,8 @@ input[type="checkbox"]:checked + label {
 /* Wider container */
 .container {
     margin-top: 70px;
-    max-width: 1600px;
-    width: 98%;
+    max-width: 1800px;
+    width: 100%;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -359,6 +359,16 @@ button {
     .remove-payload-field {
         min-width: 32px;
         min-height: 32px;
+    }
+
+    /* Smaller toggle switches on narrow screens */
+    input[type="checkbox"] + label {
+        width: 40px;
+        height: 24px;
+    }
+    input[type="checkbox"] + label::after {
+        height: 8px;
+        width: 8px;
     }
 }
 
@@ -728,9 +738,19 @@ button:disabled {
     align-items: center;
 }
 
-#clear-history.small {
-    padding: 4px 8px;
-    font-size: 12px;
+#clear-history {
+    padding: 6px 14px;
+    font-size: 14px;
+    background-color: #dc3545;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+#clear-history:hover {
+    background-color: #c82333;
 }
 
 #dispatch-history-table-wrapper {

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
     <div id="dispatch-history-container">
         <div class="history-header">
             <h2>History</h2>
-            <button id="clear-history" class="btn-action small" type="button">Clear</button>
+            <button id="clear-history" type="button">Clear</button>
         </div>
         <div id="dispatch-history-table-wrapper">
             <table id="dispatch-history-table">

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,20 @@ if (savedPat) {
     savePatCheckbox.checked = true;
 }
 
+// Load log history preference
+const savedLogPref = loadFromLocalStorage<boolean>("log_history_enabled");
+if (savedLogPref) {
+    logHistoryCheckbox.checked = true;
+}
+
+logHistoryCheckbox.addEventListener("change", () => {
+    if (logHistoryCheckbox.checked) {
+        saveToLocalStorage("log_history_enabled", true);
+    } else {
+        localStorage.removeItem("log_history_enabled");
+    }
+});
+
 // Add payload field dynamically
 addPayloadFieldButton.addEventListener("click", () => {
     const fieldDiv = document.createElement("div");
@@ -103,8 +117,10 @@ form.addEventListener("submit", async (event) => {
             errorMessage: response.ok ? null : "Workflow dispatch failed.",
         };
 
-        // Save log and refresh table
-        saveDispatchHistory(logEntry);
+        // Save log and refresh table if enabled
+        if (logHistoryCheckbox.checked) {
+            saveDispatchHistory(logEntry);
+        }
         displayDispatchHistory(loadFromLocalStorage<DispatchHistoryEntry[]>("dispatch_history") || []);
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Summary
- widen main container
- restyle clear history button
- adjust toggle switches for narrow screens
- remember dispatch log preference in local storage and honor it

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685e50185940832d9dfb07d0adf22fe8