### PR TITLE
Add GitHub test workflow and gate deployment

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,35 +1,35 @@
 name: Compile & Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Test"]
+    branches: [main]
+    types:
+      - completed
 
 permissions:
   contents: write
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16
-
       - name: Install TypeScript
         run: npm install -g typescript
-
       - name: Compile TypeScript
         run: tsc
-
       - name: Temporarily Modify .gitignore
         run: sed -i '/dist\//d' .gitignore
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a `Test` workflow that runs on pushes and PRs
- trigger deployment workflow only after the tests workflow succeeds

## Testing
- `npm ci`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e59ee5e74832d978bd534a8866a77